### PR TITLE
Restyle interface with new brand tokens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ function App() {
   return (
     <AuthProvider>
       <Router>
-        <div className="min-h-screen bg-light dark:bg-dark-300 transition-colors duration-200">
+        <div className="min-h-screen bg-canvas transition-colors duration-200">
           <Routes>
             <Route 
               path="/" 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -79,7 +79,7 @@ const Sidebar = () => {
       {/* HEADER / LOGO */}
       <div className="flex items-center h-14 px-4 border-b border-gray-100 dark:border-dark-100">
         <Link to="/" className="flex items-center space-x-2 group">
-          <div className="w-7 h-7 rounded-md bg-lime-100 dark:bg-lime-700/20 flex items-center justify-center group-hover:shadow-lg transition-all duration-300">
+          <div className="w-7 h-7 rounded-md bg-[#735CFF] flex items-center justify-center group-hover:shadow-lg transition-all duration-300">
             <img
               src="/circle-logo.png"
               alt="Allied Global"
@@ -92,8 +92,7 @@ const Sidebar = () => {
             <motion.span
               initial={false}
               animate={{ opacity: 1, width: "auto" }}
-              className="font-heading text-sm font-bold text-gray-800 dark:text-gray-200
-                         group-hover:text-lime-600 transition-colors duration-300 text-[15px]"
+              className="font-heading text-sm font-bold text-gray-800 dark:text-gray-200 group-hover:text-primary transition-colors duration-300 text-[15px]"
             >
               Allied Global
             </motion.span>
@@ -115,14 +114,14 @@ const Sidebar = () => {
                 className={cn(
                   "group flex items-center px-3 py-2 text-[14px] font-menu rounded-lg relative overflow-hidden transition-all duration-300",
                   isActive
-                    ? "text-lime-600 bg-lime-50 dark:bg-dark-100 dark:text-lime-400 font-semibold"
+                    ? "text-primary bg-primary/10 dark:bg-dark-100 dark:text-primary font-semibold"
                     : "text-gray-600 hover:text-gray-900 hover:bg-gray-50 dark:text-gray-400 dark:hover:text-white dark:hover:bg-dark-100",
                 )}
               >
                 {isActive && (
                   <motion.div
                     layoutId="activeIndicator"
-                    className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-6 bg-lime-500 dark:bg-lime-600 rounded-r-full"
+                    className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-6 bg-primary rounded-r-full"
                     initial={false}
                     transition={{
                       type: "spring",
@@ -224,13 +223,13 @@ const Sidebar = () => {
       {/*
         Small rectangular toggle at the center right
         - Now even smaller (h-7 px-1.5)
-        - Subtle border, single lime color accent
+        - Subtle border with brand accent
         - Arrow flips from left to right (0→180°)
       */}
       <div className="absolute top-1/2 right-0 -translate-y-1/2 translate-x-1/2">
         <motion.button
           onClick={() => setIsCollapsed(!isCollapsed)}
-          className="text-lime-600 dark:text-lime-400 hover:text-lime-700 dark:hover:text-lime-300 transition-colors"
+          className="text-primary hover:text-primary-600 transition-colors"
         >
           <motion.div
             animate={{ rotate: isCollapsed ? 180 : 0 }}

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,4 @@
-@import '@fontsource/noto-sans/400.css';
-@import '@fontsource/noto-sans/600.css';
-@import '@fontsource/noto-sans/700.css';
-@import '@fontsource/poppins/400.css';
-@import '@fontsource/poppins/500.css';
-@import '@fontsource/poppins/600.css';
-@import '@fontsource/lato/300.css';
-@import '@fontsource/lato/400.css';
-@import '@fontsource/lato/700.css';
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -14,37 +6,37 @@
 
 @layer base {
   body {
-    @apply bg-white text-gray-900 antialiased dark:bg-dark-300 dark:text-gray-100 text-[13px];
+    @apply bg-canvas text-gray-900 antialiased text-base font-sans;
   }
 
   h1 {
-    @apply text-2xl font-heading font-bold;
+    @apply text-3xl font-heading font-bold;
   }
 
   h2 {
-    @apply text-xl font-heading font-bold;
+    @apply text-xl font-heading font-semibold;
   }
 
   h3 {
-    @apply text-lg font-heading font-semibold;
+    @apply text-lg font-heading font-medium;
   }
 
   ::selection {
-    @apply bg-primary-100 text-primary-800 dark:bg-primary-900 dark:text-primary-100;
+    @apply bg-primary/20 text-primary;
   }
 }
 
 /* Custom button styles */
 .btn {
-  @apply inline-flex items-center justify-center px-3 py-1.5 rounded-lg font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed text-[13px];
+  @apply inline-flex items-center justify-center px-4 py-2 rounded-md font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed;
 }
 
 .btn-primary {
-  @apply bg-primary text-white hover:bg-primary-700 focus:ring-primary-600 dark:bg-primary-500 dark:hover:bg-primary-400;
+  @apply bg-gradient-to-r from-primary to-primary-600 text-white shadow hover:opacity-95 hover:-translate-y-px focus:ring-primary-600;
 }
 
 .btn-secondary {
-  @apply bg-gray-100 text-gray-700 hover:bg-gray-200 focus:ring-gray-500 dark:bg-dark-50 dark:text-gray-300 dark:hover:bg-dark-100;
+  @apply text-primary border border-primary bg-transparent hover:bg-primary/10 focus:ring-primary-600;
 }
 
 .btn-outline {
@@ -53,27 +45,25 @@
 
 /* Card styles */
 .card {
-  @apply bg-white rounded-xl shadow-sm border border-gray-100 transition-all duration-200 hover:shadow-md dark:bg-dark-200 dark:border-dark-100;
+  @apply bg-white border border-cardborder rounded-xl shadow-sm hover:shadow hover:-translate-y-px transition transform dark:bg-dark-200 dark:border-dark-100;
 }
 
 /* Input styles */
 .input {
-  @apply block w-full px-3 py-2 text-[13px] rounded-lg border shadow-sm transition-colors
-    /* Light mode styles */
+  @apply block w-full px-3 py-2 text-sm rounded-md border transition-colors
     bg-white
     text-gray-900
-    border-gray-300
+    border-cardborder
     placeholder-gray-400
     focus:border-primary-600
     focus:ring-2
     focus:ring-primary-600/20
-    /* Dark mode styles */
     dark:bg-dark-100
     dark:text-white
     dark:border-dark-50
     dark:placeholder-gray-500
-    dark:focus:border-primary-400
-    dark:focus:ring-primary-400/20;
+    dark:focus:border-primary-600
+    dark:focus:ring-primary-600/20;
 }
 
 .input-with-icon {
@@ -145,7 +135,7 @@
 
 /* Gradient borders */
 .gradient-border {
-  @apply relative p-[1px] rounded-xl bg-gradient-to-r from-primary-500 to-primary-400;
+  @apply relative p-[1px] rounded-xl bg-gradient-to-r from-primary to-primary-600;
 }
 .gradient-border > * {
   @apply bg-white dark:bg-dark-200 rounded-[inherit];
@@ -184,7 +174,7 @@
   @apply inline-flex items-center px-2 py-0.5 rounded text-[12px] font-medium;
 }
 .badge-primary {
-  @apply bg-primary-100 text-primary-800 dark:bg-primary-900 dark:text-primary-100;
+  @apply bg-primary/10 text-primary;
 }
 .badge-secondary {
   @apply bg-gray-100 text-gray-800 dark:bg-dark-100 dark:text-gray-200;
@@ -203,12 +193,12 @@
 }
 
 .radio-switch:hover {
-  @apply border-primary/50 dark:border-primary-400/50;
+  @apply border-primary/50 dark:border-primary-600/50;
 }
 
 .radio-switch:checked {
   /* Selected state */
-  @apply border-primary bg-primary dark:border-primary-400 dark:bg-primary-400;
+  @apply border-primary bg-primary dark:border-primary-600 dark:bg-primary-600;
 }
 
 .radio-switch:checked::after {
@@ -218,12 +208,12 @@
 }
 
 .radio-switch:focus {
-  @apply outline-none ring-2 ring-primary/20 dark:ring-primary-400/20;
+  @apply outline-none ring-2 ring-primary/20 dark:ring-primary-600/20;
 }
 
 /* Hero section gradient text */
 .gradient-text {
-  @apply bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent;
+  @apply bg-gradient-to-r from-primary to-primary-600 bg-clip-text text-transparent;
 }
 
 /* Mouse trail effect */
@@ -238,7 +228,7 @@
 
 /* Feature card gradients */
 .feature-card-primary {
-  @apply bg-gradient-to-br from-primary-500/10 to-primary-600/5 hover:from-primary-500/20 hover:to-primary-600/10;
+  @apply bg-gradient-to-br from-primary/20 to-primary/10 hover:from-primary/30 hover:to-primary/20;
 }
 .feature-card-indigo {
   @apply bg-gradient-to-br from-indigo-500/10 to-indigo-600/5 hover:from-indigo-500/20 hover:to-indigo-600/10;
@@ -249,7 +239,7 @@
 
 /* Feature card icons */
 .icon-primary {
-  @apply bg-gradient-to-br from-primary-500/20 to-primary-600/10 text-primary-500;
+  @apply bg-gradient-to-br from-primary/20 to-primary/10 text-primary;
 }
 .icon-indigo {
   @apply bg-gradient-to-br from-indigo-500/20 to-indigo-600/10 text-indigo-500;

--- a/src/pages/dashboard/Agents.tsx
+++ b/src/pages/dashboard/Agents.tsx
@@ -728,7 +728,7 @@ const Agents = () => {
                               colorClasses[color]
                             } dark:from-opacity-30 dark:to-opacity-20 flex items-center justify-center`}
                           >
-                            <Icon className="w-6 h-6 text-lime-500 dark:text-lime-500" />
+                            <Icon className="w-6 h-6 text-primary" />
                           </div>
                         </div>
                         <div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,33 +5,30 @@ export default {
   theme: {
     extend: {
       fontSize: {
-        xs: "0.6875rem", // 11px
-        sm: "0.75rem", // 12px
-        base: "0.8125rem", // 13px
-        lg: "0.875rem", // 14px
-        xl: "1rem", // 16px
-        "2xl": "1.125rem", // 18px
-        "3xl": "1.25rem", // 20px
-        "4xl": "1.5rem", // 24px
+        xs: "0.75rem", // 12px
+        sm: "0.875rem", // 14px
+        base: "1rem", // 16px body text
+        lg: "1.125rem", // 18px
+        xl: "1.25rem", // 20px card titles
+        "2xl": "1.5rem", // 24px
+        "3xl": "2rem", // 32px h1
       },
       fontFamily: {
-        sans: ["Poppins", "system-ui", "sans-serif"],
-        heading: ["Noto Sans", "system-ui", "sans-serif"],
-        menu: ["Lato", "system-ui", "sans-serif"],
+        sans: ["Inter", "system-ui", "sans-serif"],
+        heading: ["Inter", "system-ui", "sans-serif"],
+        menu: ["Inter", "system-ui", "sans-serif"],
       },
       colors: {
         primary: {
-          DEFAULT: "#65a30d", // Lime-600 as default for better contrast
-          50: "#f7fee7",
-          100: "#ecfccb",
-          200: "#d9f99d",
-          300: "#bef264",
-          400: "#a3e635",
-          500: "#84cc16",
-          600: "#65a30d",
-          700: "#4d7c0f",
-          800: "#3f6212",
-          900: "#365314",
+          DEFAULT: "#1E82FF",
+          600: "#6A5CFF",
+        },
+        canvas: "#F6F8FA",
+        cardborder: "#E3E7EE",
+        accent: {
+          purple: "#735CFF",
+          teal: "#00C896",
+          orange: "#FF8F44",
         },
         dark: {
           DEFAULT: "#18181b",


### PR DESCRIPTION
## Summary
- adopt Inter across the theme
- define brand colours and canvas in Tailwind config
- rework base styles for buttons, cards and inputs
- switch app shell to the new canvas background
- adjust sidebar and agents list colours

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68893751fdd483228d5c549ab59fcbb4